### PR TITLE
Fix usage as a module

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,2 @@
+require("./source/SVG.js");
+require("./source/markerTypes/shapeMarker.js");


### PR DESCRIPTION
I found that trying to build this with yarn together with other modules using `require(...)` failed. `package.json` mentions an `index.js` file but that is missing.

A simple `index.js` fixes this and allows embedding the plugin properly.