### PR TITLE
Adds arrowhead shape options

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ L.shapeMarker also extends the [path class](http://leafletjs.com/reference.html#
 * triangle (= triangle-up)
 * triangle-up
 * triangle-down
+* arrowhead (= arrowhead-up)
+* arrowhead-up
+* arrowhead-down
 * circle
 * x
 

--- a/source/SVG.js
+++ b/source/SVG.js
@@ -21,14 +21,14 @@ L.SVG.include({
 			var d = "M" + (p.x - (13/10*s)) + " " + (p.y - (0.75*s)) + " L" + (p.x) + " " + (p.y + (1.5*s)) + " L" + (p.x + (13/10*s)) + " " + (p.y - (0.75*s)) + " Z";
 			this._setPath(layer, d);
 		}
-    if (shape === "arrowhead" || shape === "arrowhead-up") {
-      var d = "M " + (p.x + (1.3*s)) + " " + (p.y + (1.3*s)) + " L " + (p.x) + " " + (p.y - (1.3*s)) + " L " + (p.x - (1.3*s)) + " " + (p.y + (1.3*s)) + " L " + (p.x) + " " + (p.y + (0.5 * s)) + " L " + (p.x + (1.3*s)) + " " + (p.y + (1.3*s)) + " Z";
-      this._setPath(layer, d);
-    }
-    if (shape === "arrowhead-down") {
-      var d = "M " + (p.x - (1.3*s)) + " " + (p.y - (1.3*s)) + " L " + (p.x) + " " + (p.y + (1.3*s)) + " L " + (p.x + (1.3*s)) + " " + (p.y - (1.3*s)) + " L " + (p.x) + " " + (p.y - (0.5 * s)) + " L " + (p.x - (1.3*s)) + " " + (p.y - (1.3*s)) + " Z";
-      this._setPath(layer, d);
-    }
+		if (shape === "arrowhead" || shape === "arrowhead-up") {
+			var d = "M " + (p.x + (1.3*s)) + " " + (p.y + (1.3*s)) + " L " + (p.x) + " " + (p.y - (1.3*s)) + " L " + (p.x - (1.3*s)) + " " + (p.y + (1.3*s)) + " L " + (p.x) + " " + (p.y + (0.5 * s)) + " L " + (p.x + (1.3*s)) + " " + (p.y + (1.3*s)) + " Z";
+			this._setPath(layer, d);
+		}
+		if (shape === "arrowhead-down") {
+			var d = "M " + (p.x - (1.3*s)) + " " + (p.y - (1.3*s)) + " L " + (p.x) + " " + (p.y + (1.3*s)) + " L " + (p.x + (1.3*s)) + " " + (p.y - (1.3*s)) + " L " + (p.x) + " " + (p.y - (0.5 * s)) + " L " + (p.x - (1.3*s)) + " " + (p.y - (1.3*s)) + " Z";
+			this._setPath(layer, d);
+		}
 		if (shape === "circle") {
 			this._updateCircle(layer)
 		}

--- a/source/SVG.js
+++ b/source/SVG.js
@@ -21,6 +21,14 @@ L.SVG.include({
 			var d = "M" + (p.x - (13/10*s)) + " " + (p.y - (0.75*s)) + " L" + (p.x) + " " + (p.y + (1.5*s)) + " L" + (p.x + (13/10*s)) + " " + (p.y - (0.75*s)) + " Z";
 			this._setPath(layer, d);
 		}
+    if (shape === "arrowhead" || shape === "arrowhead-up") {
+      var d = "M " + (p.x + (1.3*s)) + " " + (p.y + (1.3*s)) + " L " + (p.x) + " " + (p.y - (1.3*s)) + " L " + (p.x - (1.3*s)) + " " + (p.y + (1.3*s)) + " L " + (p.x) + " " + (p.y + (0.5 * s)) + " L " + (p.x + (1.3*s)) + " " + (p.y + (1.3*s)) + " Z";
+      this._setPath(layer, d);
+    }
+    if (shape === "arrowhead-down") {
+      var d = "M " + (p.x - (1.3*s)) + " " + (p.y - (1.3*s)) + " L " + (p.x) + " " + (p.y + (1.3*s)) + " L " + (p.x + (1.3*s)) + " " + (p.y - (1.3*s)) + " L " + (p.x) + " " + (p.y - (0.5 * s)) + " L " + (p.x - (1.3*s)) + " " + (p.y - (1.3*s)) + " Z";
+      this._setPath(layer, d);
+    }
 		if (shape === "circle") {
 			this._updateCircle(layer)
 		}


### PR DESCRIPTION
I found the triangle options were difficult to read as up / down indicators when they were close together so I forked to add arrowhead options that seem to be a cleaner way to show this.

I wasn't sure what files to modify, but assumed just the source folder and readme.

No online demo, but a screenshot from my local setup

![icons](https://user-images.githubusercontent.com/32726262/89381665-dd5b9e00-d73c-11ea-8ff6-43bdc4c495ef.png)

Settings used from that screenshot

```
var iconSettings = {
  fillColor: "#1ae43b",
  color: "#1a613b",
  fillOpacity: 0.7,
  shape: "arrowhead",
  radius: 4,
  fillOpacity: 0.9,
  weight: 1
};
var _icon = Object.assign({},iconSettings);
L.shapeMarker([-32.4785, 142.9864], _icon).addTo(map);

_icon = Object.assign({},iconSettings, {shape: "arrowhead-down"});
L.shapeMarker([-32.4785, 143.9864], _icon).addTo(map);
```
Cheers