### PR TITLE
Extend CircleMarker instead of Path

### DIFF
--- a/dist/leaflet-svg-shape-markers.js
+++ b/dist/leaflet-svg-shape-markers.js
@@ -42,70 +42,15 @@ L.SVG.include({
 		}
 	}
 });
-;L.ShapeMarker = L.Path.extend({
+L.ShapeMarker = L.CircleMarker.extend({
 	options: {
 		fill: true,
 		shape: 'triangle',
 		radius: 10
 	},
 
-	initialize: function (latlng, options) {
-		L.setOptions(this, options);
-		this._latlng = L.latLng(latlng);
-		this._radius = this.options.radius;
-	},
-
-	setLatLng: function (latlng) {
-		this._latlng = L.latLng(latlng);
-		this.redraw();
-		return this.fire('move', {latlng: this._latlng});
-	},
-
-	getLatLng: function () {
-		return this._latlng;
-	},
-
-	setRadius: function (radius) {
-		this.options.radius = this._radius = radius;
-		return this.redraw();
-	},
-
-	getRadius: function () {
-		return this._radius;
-	},
-
-	setStyle : function (options) {
-		var radius = options && options.radius || this._radius;
-		L.Path.prototype.setStyle.call(this, options);
-		this.setRadius(radius);
-		return this;
-	},
-
-	_project: function () {
-		this._point = this._map.latLngToLayerPoint(this._latlng);
-		this._updateBounds();
-	},
-
-	_updateBounds: function () {
-		var r = this._radius,
-			r2 = this._radiusY || r,
-			w = this._clickTolerance(),
-			p = [r + w, r2 + w];
-		this._pxBounds = new L.Bounds(this._point.subtract(p), this._point.add(p));
-	},
-
-	_update: function () {
-		if (this._map) {
-			this._updatePath();
-		}
-	},
-
 	_updatePath: function () {
 		this._renderer._updateShape(this);
-	},
-
-	_empty: function () {
-		return this._size && !this._renderer._bounds.intersects(this._pxBounds);
 	},
 
 	toGeoJSON: function () {


### PR DESCRIPTION
The original L.ShapeMarker extended L.Path and essentially existed as a modified clone of L.CircleMarker. I've explicitly made L.ShapeMarker extend CircleMarker instead. This also makes it unnecessary to explicitly define methods like `getLatLng` and `setStyle`.

Could resolve [some](https://github.com/rowanwins/Leaflet.SvgShapeMarkers/issues/4) [related](https://github.com/zakjan/leaflet-lasso/issues/29) [issues](https://github.com/stefanocudini/leaflet-search/issues/230).